### PR TITLE
ci: using app id instead of user

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: call-test-workflow
     steps:
-      - uses: actions/checkout@v3
+      # Use our auto-commit permissioned app for our git actions
+      - uses: actions/create-github-app-token@v1
+        id: app-token
         with:
-          token: ${{ secrets.RELEASE_PAT }}
+          app-id: ${{ secrets.AUTO_COMMIT_APP_ID }}
+          private-key: ${{ secrets.AUTO_COMMIT_APP_PKEY }}
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
# Description

This adds use of the github app token so that we can have  a more resilient auto-commit deploy process