### PR TITLE
ci: supports using forked repos during commit linting

### DIFF
--- a/.github/workflows/test-flow.yaml
+++ b/.github/workflows/test-flow.yaml
@@ -42,7 +42,7 @@ jobs:
           if [[ "${{ github.base_ref }}" != "" ]]; then
             echo "Setting up git environment for commitlint of pull request"
             git fetch origin ${{ github.base_ref }}
-            git fetch origin ${{ github.head_ref }}
+            git fetch ${{ github.event.pull_request.head.repo.clone_url }} ${{ github.head_ref }}
             npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
           else
             echo "Setting up git environment for commitlint of branch push"


### PR DESCRIPTION
# Summary

This fixes the fact that when a fork is opened up, the origins aren't the same and therefore we need to pull the correct branch for commitlint